### PR TITLE
Update to 1.18(.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![FlyPerms](resource/FlyPerms.png)
 
 ![Plugin-Version](https://img.shields.io/spiget/version/83432?label=version)
-![MC-version](https://img.shields.io/badge/minecraft-java%20edition%201.8.8%2B-blueviolet)
-![Java](https://img.shields.io/badge/java-version%208%2B%20-orange)
+![MC-version](https://img.shields.io/badge/minecraft-java%20edition%201.16.5%2B-blueviolet)
+![Java](https://img.shields.io/badge/java-version%2016%2B%20-orange)
 ![Downloads](https://img.shields.io/spiget/downloads/83432?label=downloads)
 ![Rating](https://img.shields.io/spiget/rating/83432?label=rating)
 [![License](https://img.shields.io/github/license/benwoo1110/FlyPerms)](LICENSE)
@@ -17,7 +17,7 @@
 * Able to disable this plugin per world!
 * Change your fly speed with speed groups!
 * Supports all modern permission plugins (Recommended [LuckPerms](https://luckperms.net/download))
-* Supports 1.8.8 servers and later!
+* Supports 1.16.5 servers and later! (For 1.8-1.15 use [Version 2.2.0](https://www.spigotmc.org/resources/flyperms-1-8-1-17.83432/download?version=391913))
 * WorldGuard Support!
 
 ## Support

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
 
     <groupId>dev.benergy10.flyperms</groupId>
     <artifactId>FlyPerms</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.3.0</version>
     <packaging>jar</packaging>
 
     <name>FlyPerms</name>
 
     <description>Toggle ability to fly based on permission</description>
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>16</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -35,7 +35,7 @@
             <!-- Always create javadoc jar. -->
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>
@@ -175,25 +175,25 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.17.1-R0.1-SNAPSHOT</version>
+            <version>1.18.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
-            <version>7.0.5</version>
+            <version>7.0.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.10</version>
+            <version>2.11.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>21.0.1</version>
+            <version>23.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: FlyPerms
 version: ${project.version}
-api-version: 1.13
+api-version: 1.16
 main: dev.benergy10.flyperms.FlyPerms
 author: benwoo1110
 description: Toggle ability to fly based on permissions!


### PR DESCRIPTION
This pr just updates FlyPerms "internals" and makes it officially 1.18 compatible (Seems to already run fine on 1.18 as there are already people using it on 1.18 according to bStats)